### PR TITLE
AllowGenerateParams and GenerateCommands Setting Additions

### DIFF
--- a/MarkovChainBot.py
+++ b/MarkovChainBot.py
@@ -76,6 +76,7 @@ class MarkovChain:
         self.enable_generate_command = settings["EnableGenerateCommand"]
         self.sent_separator = settings["SentenceSeparator"]
         self.allow_generate_params = settings["AllowGenerateParams"]
+        self.generate_commands = tuple(settings["GenerateCommands"])
 
     def message_handler(self, m: Message):
         try:
@@ -518,15 +519,15 @@ class MarkovChain:
         return message.split()[0] in commands
 
     def check_if_generate(self, message: str) -> bool:
-        """True if the first "word" of the message is either !generate or !g.
+        """True if the first "word" of the message is one of the defined generate commands.
 
         Args:
-            message (str): The message to check for !generate or !g.
+            message (str): The message to check for the generate command (i.e !generate or !g).
         
         Returns:
-            bool: True if the first word in message is !generate or !g.
+            bool: True if the first word in message is a generate command.
         """
-        return self.check_if_our_command(message, "!generate", "!g")
+        return self.check_if_our_command(message, *self.generate_commands)
     
     def check_if_other_command(self, message: str) -> bool:
         """True if the message is any command, except /me. 

--- a/MarkovChainBot.py
+++ b/MarkovChainBot.py
@@ -75,6 +75,7 @@ class MarkovChain:
         self.whisper_cooldown = settings["WhisperCooldown"]
         self.enable_generate_command = settings["EnableGenerateCommand"]
         self.sent_separator = settings["SentenceSeparator"]
+        self.allow_generate_params = settings["AllowGenerateParams"]
 
     def message_handler(self, m: Message):
         try:
@@ -148,7 +149,7 @@ class MarkovChain:
                         if self.check_filter(m.message):
                             sentence = "You can't make me say that, you madman!"
                         else:
-                            params = tokenize(m.message)[2:]
+                            params = tokenize(m.message)[2:] if self.allow_generate_params else None
                             # Generate an actual sentence
                             sentence, success = self.generate(params)
                             if success:

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ This bot is controlled by a `settings.json` file, which has the following struct
   "WhisperCooldown": true,
   "EnableGenerateCommand": true,
   "SentenceSeparator": " - ",
+  "AllowGenerateParams": True,
+  "GenerateCommands": ["!generate", "!g"]
 }
 ```
 
@@ -256,6 +258,8 @@ This bot is controlled by a `settings.json` file, which has the following struct
 | `WhisperCooldown`          | Allows the bot to whisper a user the remaining cooldown after that user has attempted to generate a message.                                                                                                                                 | `true`                                                  |
 | `EnableGenerateCommand`    | Globally enables/disables the generate command.                                                                                                                                                                                              | `true`                                                  |
 | `SentenceSeparator`        | The separator between multiple sentences. Only relevant if `MinSentenceWordAmount` > 0, as only then can multiple sentences be generated. Sensible values for this might be `", "`, `". "`, `" - "` or `" "`.                                | `" - "`                                                 | 
+| `AllowGenerateParams`      | Allow chat to supply a partial sentence which the bot finishes, e.g. `!generate hello, I am`. If `false`, all values after the generation command will be ignored.                                                                           | `true`                                                  |
+| `GenerateCommands`         | The generation commands that the bot will listen for. Defaults to `["!generate", "!g"]`. Useful if your chat is used to commands with `~`, `-`, `/`, etc.                                                                                    | `["!generate", "!g"]`                                   |
 
 _Note that the example OAuth token is not an actual token, but merely a generated string to give an indication what it might look like._
 

--- a/Settings.py
+++ b/Settings.py
@@ -47,6 +47,7 @@ class Settings:
         "WhisperCooldown": True,
         "EnableGenerateCommand": True,
         "SentenceSeparator": " - ",
+        "AllowGenerateParams": True
     }
 
     def __init__(self, bot) -> None:

--- a/Settings.py
+++ b/Settings.py
@@ -85,6 +85,18 @@ class Settings:
                 settings: SettingsData = json.loads(text_settings)
                 Settings.update_v1(settings)
 
+                # Check if any settings keys are missing, and if so, write the defaults
+                # to the settings.json
+                if settings.keys() != Settings.DEFAULTS.keys():
+                    missing_keys = set(Settings.DEFAULTS.keys()) - set(settings.keys())
+                    # Log the missing keys
+                    logger.info(f"The following keys were missing from {Settings.PATH}: {', '.join(map(repr, missing_keys))}.")
+                    logger.info(f"These defaults of these values were used, and added to {Settings.PATH}. Default behaviour will not change.")
+
+                    # Add missing defaults
+                    settings = {**Settings.DEFAULTS, **settings}
+                    Settings.write_settings_file(settings)
+
                 return settings
 
         except ValueError:
@@ -161,8 +173,12 @@ class Settings:
     @staticmethod
     def write_default_settings_file() -> None:
         """Create a standardised settings file with default values."""
+        Settings.write_settings_file(Settings.DEFAULTS)
+
+    @staticmethod
+    def write_settings_file(settings: SettingsData) -> None:
         with open(Settings.PATH, "w") as f:
-            f.write(json.dumps(Settings.DEFAULTS, indent=4, separators=(",", ": ")))
+            f.write(json.dumps(settings, indent=4, separators=(",", ": ")))
 
     @staticmethod
     def update_cooldown(cooldown: int) -> None:

--- a/Settings.py
+++ b/Settings.py
@@ -47,7 +47,8 @@ class Settings:
         "WhisperCooldown": True,
         "EnableGenerateCommand": True,
         "SentenceSeparator": " - ",
-        "AllowGenerateParams": True
+        "AllowGenerateParams": True,
+        "GenerateCommands": ["!generate", "!g"]
     }
 
     def __init__(self, bot) -> None:


### PR DESCRIPTION
- `AllowGenerateParams` allows the bot owner to toggle if params can be used or will be ignored when the generate command is run
- `GenerateCommands` allows the default !generate and !g commands to be changed